### PR TITLE
Add files via upload

### DIFF
--- a/rd_exonoodle.py
+++ b/rd_exonoodle.py
@@ -1,0 +1,158 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Functions:
+    
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+def rd_exonoodle(noodle_folder,phase_in=-1,tol=1e-5):
+# reads exonoodle output files: either all or at a specific phase
+# tol: how accurate the input phase should be
+    data_time=np.genfromtxt(noodle_folder+'times.dat',skip_header=13)
+    n_digits=len(str(len(data_time))) #number of files's digits to make file_index's format
+    file_index,phase,time=data_time[:,0],data_time[:,1],data_time[:,2]
+
+    exonoodle_spectra=[]
+    if(0<=phase_in)&(phase_in<=1):
+        print('Reading exonoodle spectrum at phase {}'.format(phase_in))
+        # read spectrum at a specific phase
+        near_bool,indx=find_nearest(phase, phase_in,tol)
+        if(near_bool):
+            i, p, t=file_index[indx], phase[indx],time[indx]
+            
+            f_ind="{:d}".format(int(i)).rjust(n_digits).replace(' ','0')
+            data_spec=np.genfromtxt(noodle_folder+'SED_'+f_ind+'.dat',skip_header=12)
+            dict_spec = {
+                        "file": noodle_folder+'SED_'+f_ind+'.dat',
+                        "phase": p,
+                        "time": t,
+                        "wavelength": data_spec[:,0],
+                        "spectrum": data_spec[:,1]
+                        }
+            exonoodle_spectra.append(dict_spec)
+        else:
+            print('Phase NOT found! Choose a phase from:',phase)
+            
+
+    else:
+        print('Reading exonoodle spectra at all phases ...')
+        for i, p, t in zip(file_index, phase,time):
+            f_ind="{:d}".format(int(i)).rjust(n_digits).replace(' ','0')
+            data_spec=np.genfromtxt(noodle_folder+'SED_'+f_ind+'.dat',skip_header=12)
+            dict_spec = {
+                        "file": noodle_folder+'SED_'+f_ind+'.dat',
+                        "phase": p,
+                        "time": t,
+                        "wavelength": data_spec[:,0],
+                        "spectrum": data_spec[:,1]
+                        }
+            exonoodle_spectra.append(dict_spec)
+
+    return exonoodle_spectra
+
+
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+def rd_exonoodle_filename(noodle_folder,phase_in=-1,tol=1e-5):
+# reads exonoodle output file names: either all or at a specific phase
+# tol: how accurate the input phase should be
+    data_time=np.genfromtxt(noodle_folder+'times.dat',skip_header=13)
+    n_digits=len(str(len(data_time))) #number of files's digits to make file_index's format
+    file_index,phase,time=data_time[:,0],data_time[:,1],data_time[:,2]
+
+    exonoodle_files=[]
+    phases=[]
+    if(0<=phase_in)&(phase_in<=1):
+        print('Reading exonoodle file name at phase {}'.format(phase_in))
+        # read spectrum at a specific phase
+        near_bool,indx=find_nearest(phase, phase_in,tol)
+        if(near_bool):
+            i, p, t=file_index[indx], phase[indx],time[indx]
+            f_ind="{:d}".format(int(i)).rjust(n_digits).replace(' ','0')
+            exonoodle_files.append(noodle_folder+'SED_'+f_ind+'.dat')
+            phases.append(p)
+        else:
+            print('Phase NOT found! Choose a phase from:',phase)
+    else:
+        # reads all exonoodle output files with time and phase stamp
+        print('Reading exonoodle file names at all phases ...')
+        for i, p, t in zip(file_index, phase,time):
+            f_ind="{:d}".format(int(i)).rjust(n_digits).replace(' ','0')
+            exonoodle_files.append(noodle_folder+'SED_'+f_ind+'.dat')
+            phases.append(p)
+
+    return exonoodle_files, phases
+
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+def find_nearest(array, value,tol):
+    #Check if values are almost equal. If yes, then what's the index? (for phase comparison)
+    near_bool=False
+    array = np.asarray(array)
+    idx = (np.abs(array - value)).argmin()
+    if(any(np.abs(array - value)<=tol)):
+        near_bool=True
+    return near_bool,idx 
+
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+def plt_exonoodle(exonoodle_spectra):
+    cm = plt.get_cmap('plasma') #gist_rainbow
+    N=len(exonoodle_spectra)
+    for i,d in enumerate(exonoodle_spectra):
+        wln,sed,phase=d["wavelength"],d["spectrum"],d["phase"]
+        if(N>1):
+            plt.plot(wln,sed,lw=.7,color=cm(float(i)/float(N-1)),label="{:.3f}".format(phase))
+        else:
+            plt.plot(wln,sed,lw=.7,label="{:.3f}".format(phase))
+ 
+    plt.yscale('log')
+    plt.legend(title='Phase',fontsize=5)
+    plt.xlabel("Wavelength ($\mu$m)")
+    plt.ylabel("flux ($\mu$Jy)")
+    
+    return
+
+
+
+
+
+# #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# # How to use:
+
+# # exonoodle output directory
+# noodle_folder = 'output_bb_noLD/Noodles_2021-02-26/'
+
+# # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# # Examplea of reading exonoodle output file names with time and phase stamps
+
+# # read all spectra
+# # exonoodle_fname_all, phases=rd_exonoodle_filename(noodle_folder)
+# # print(exonoodle_fname_all)
+# # read spectrum at a specific phase
+# exonoodle_fname_singlephase, phases=rd_exonoodle_filename(noodle_folder,phase_in=0.46666)
+# print(exonoodle_fname_singlephase)
+
+
+# # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# # Examplea of reading exonoodle output files with time and phase stamps
+
+# # read all spectra
+# exonoodle_spectra_all=rd_exonoodle(noodle_folder)
+# # read spectrum at a specific phase
+# exonoodle_spectra_singlephase=rd_exonoodle(noodle_folder,phase_in=0.46666)
+
+
+# # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# # Plot all exonoodle output files
+# plt_exonoodle(exonoodle_spectra_singlephase)
+# plt_exonoodle(exonoodle_spectra_all)
+
+
+
+

--- a/wasp43b_test_mirisim.py
+++ b/wasp43b_test_mirisim.py
@@ -1,82 +1,104 @@
-import numpy as np
-import matplotlib.pyplot as plt
-import pdb
-import glob
+# import numpy as np
+# import matplotlib.pyplot as plt
+# import pdb
+# import glob
 
 from mirisim.config_parser import SimulatorConfig, SimConfig, SceneConfig
 from mirisim import MiriSimulation
 from mirisim.skysim import ExternalSed, Background, Point
 
+import rd_exonoodle as rdexon
 
-# in this script I'm going to take one output spectrum from exonoodle, and produce a very simple exposure with ngroups of 65
+
+def mirisim_exonoodle(sedfile,phase,overwrite=True):
+    
+    target = Point(Cen=(0., 0.))
+
+    sed = ExternalSed(sedfile=sedfile)
+    target.set_SED(sed)
+    
+    bg = Background(level='low', gradient=0., pa=0.)
+    # scene = target + bg    
+    
+    # create the target list for the scene file, make the scene and write out to file
+    targetlist = [target]
+    scene_config = SceneConfig.makeScene(loglevel=0, background=bg, targets=targetlist)
+    scene_file = 'wasp43b_simple_scene.ini'
+    scene_config.write(scene_file, overwrite=True) #change if overwrite is not desired
+    
+    # now set up the simulation parameters
+    op_path = 'IMA'
+    cfg = 'LRS_SLITLESS'
+    filt = 'P750L'
+    subarr = 'SLITLESSPRISM'
+    
+    # exposure configuration
+    ngrp = 65
+    nint = 5
+    nexp = 1
+    
+    simname = 'wasp43b_ers_shorttest'
+    
+    sim_config = SimConfig.makeSim(
+        name = simname,    # name given to simulation
+        scene = scene_file, # name of scene file to input
+        rel_obsdate = 1.0,          # relative observation date (0 = launch, 1 = end of 5 yrs)
+        POP = op_path,                # Component on which to center (Imager or MRS)
+        ConfigPath = cfg,  # Configure the Optical path (MRS sub-band)
+        Dither = False,             # Don't Dither
+        StartInd = 1,               # start index for dither pattern [NOT USED HERE]
+        NDither = 2,                # number of dither positions [NOT USED HERE]
+        DitherPat = 'ima_recommended_dither.dat', # dither pattern to use [NOT USED HERE]
+        disperser = 'SHORT',        # [NOT USED HERE]
+        detector = 'SW',            # [NOT USED HERE]
+        mrs_mode = 'SLOW',          # [NOT USED HERE]
+        mrs_exposures = 10,          # [NOT USED HERE]
+        mrs_integrations = 3,       # [NOT USED HERE]
+        mrs_frames = 5,             # [NOT USED HERE]
+        ima_exposures = nexp,          # number of exposures
+        ima_integrations = nint,       # number of integrations
+        ima_frames = ngrp,             # number of groups (for MIRI, # Groups = # Frames)
+        ima_mode = 'FAST',          # Imager read mode (default is FAST ~ 2.3 s)
+        filter = filt,          # Imager Filter to use
+        readDetect = subarr         # Portion of detector to read out,
+    )	
+    
+    # write the simulation config out to file, if out was set to True. the output filename is the simname, followed b the number of groups, ints and exp, for easy reference.
+    simout = '{0}_simconfig.ini'.format(simname)
+    sim_config.write(simout, overwrite=True) #change if overwrite is not desired
+    	
+    # set up the simulator "under the hood". deafult values can be accepted here.
+    # simulator_config = SimulatorConfig.from_default()
+    
+    
+    sim = MiriSimulation.from_configfiles(simout)
+    sim.run()
+    
+    return
+
+
+
+
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Take output spectra from exonoodle, and produce a very simple exposure with ngroups of 65
 
 noodle_folder = 'output_bb_noLD/Noodles_2021-02-26/'
 
-# load in a list of the files in the output folder
-files = glob.glob(noodle_folder+'*.dat')
-print('{} files found'.format(len(files)))
+# Read all exonoodle spectra or at a given phase:
+# sedfiles, phases=rdexon.rd_exonoodle_filename(noodle_folder) # all phases
+sedfiles, phases=rdexon.rd_exonoodle_filename(noodle_folder,phase_in=0.46666) # at a given phase; ~0 or ~1:transit and ~0.5:eclipse
 
-target = Point(Cen=(0., 0.))
-
-# let's pick file 8 which is in eclipse for SED, and assign to target
-sed = ExternalSed(sedfile=files[8])
-target.set_SED(sed)
-
-bg = Background(level='low', gradient=0., pa=0.)
-scene = target + bg    
-
-# create the target list for the scene file, make the scene and write out to file
-targetlist = [target]
-scene_config = SceneConfig.makeScene(loglevel=0, background=bg, targets=targetlist)
-scene_file = 'wasp43b_simple_scene.ini'
-scene_config.write(scene_file)
-
-# now set up the simulation parameters
-op_path = 'IMA'
-cfg = 'LRS_SLITLESS'
-filt = 'P750L'
-subarr = 'SLITLESSPRISM'
-
-# exposure configuration
-ngrp = 65
-nint = 5
-nexp = 1
-
-simname = 'wasp43b_ers_shorttest'
-
-sim_config = SimConfig.makeSim(
-    name = simname,    # name given to simulation
-    scene = scene_file, # name of scene file to input
-    rel_obsdate = 1.0,          # relative observation date (0 = launch, 1 = end of 5 yrs)
-    POP = op_path,                # Component on which to center (Imager or MRS)
-    ConfigPath = cfg,  # Configure the Optical path (MRS sub-band)
-    Dither = False,             # Don't Dither
-    StartInd = 1,               # start index for dither pattern [NOT USED HERE]
-    NDither = 2,                # number of dither positions [NOT USED HERE]
-    DitherPat = 'ima_recommended_dither.dat', # dither pattern to use [NOT USED HERE]
-    disperser = 'SHORT',        # [NOT USED HERE]
-    detector = 'SW',            # [NOT USED HERE]
-    mrs_mode = 'SLOW',          # [NOT USED HERE]
-    mrs_exposures = 10,          # [NOT USED HERE]
-    mrs_integrations = 3,       # [NOT USED HERE]
-    mrs_frames = 5,             # [NOT USED HERE]
-    ima_exposures = nexp,          # number of exposures
-    ima_integrations = nint,       # number of integrations
-    ima_frames = ngrp,             # number of groups (for MIRI, # Groups = # Frames)
-    ima_mode = 'FAST',          # Imager read mode (default is FAST ~ 2.3 s)
-    filter = filt,          # Imager Filter to use
-    readDetect = subarr         # Portion of detector to read out,
-)	
-
-# write the simulation config out to file, if out was set to True. the output filename is the simname, followed b the number of groups, ints and exp, for easy reference.
-simout = '{0}_simconfig.ini'.format(simname)
-sim_config.write(simout)
-	
-# set up the simulator "under the hood". deafult values can be accepted here.
-simulator_config = SimulatorConfig.from_default()
+#Run MIRISim with a simple setup
+for sedfile, phase in zip(sedfiles, phases):
+    print('Reading exonoodle spectrum at phase {}'.format(phase))
+    # print(sedfile)
+    mirisim_exonoodle(sedfile,phase,overwrite=True) #overwrites .ini files; turn it off by overwrite=Flase
 
 
-sim = MiriSimulation.from_configfiles(simout)
-sim.run()
+
+
 
 


### PR DESCRIPTION
Reads exonoodle output files (either all or at a specific orbital phase) and calculate a simple MIRI exposure with ngroups of 65. (Note: In the original script, glob does not sort the files by default and hence picking file 8 does not represent the spectrum at eclipse.)